### PR TITLE
Prod 2741 update to use new version and remove origin parameter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ jobs:
             event_name: deployment
             event_action: succeeded
             origin: circleci-orb
+            vcs_type: github
 
 workflows:
    events_example_workflow:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,8 +16,6 @@ jobs:
             environment: staging
             event_name: deployment
             event_action: succeeded
-            origin: circleci-orb
-            vcs_type: github
 
 workflows:
    events_example_workflow:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 description: "Example showing how to send a workflow metric events to CTO.ai. Set CTOAI_EVENTS_API_TOKEN and CTOAI_EVENTS_API_TEAM_ID env vars in CircleCI settings."
 
 orbs:
-  cto-ai: cto-ai/cto-ai@1.0.2
+  cto-ai: cto-ai/cto-ai@1.0.3
 
 jobs:
    events_example_job:

--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ Use the Orb to send events to CTO.ai by calling it from your `steps`:
             commit: pipeline-label-A1
             image: branch-label-543
             name: user
-            origin: shell
-            vcs_type: github
 ```
 
 Note: only `token` and `team_id` are required fields. The other fields are optional.
@@ -30,9 +28,7 @@ Note: only `token` and `team_id` are required fields. The other fields are optio
 
 You can set your environmenta variables in a CircleCI Context, in your Organization Settings, or on your Project Settings. The environment variable must then be accessed from the user's CircleCI config (e.g. `CTOAI_EVENTS_API_TOKEN` as seen above) and passed to the Orb to use the CTO.ai Events API.
 
-The `team_id` is also a required field, and could also be accessed using an environment variable as shown in the example above. Since the `team_id` is not a secret, however, this is not strictly necessary. It could be supplied directly in your config file.
-
-The `vcs_type` parameter specifies the vcs used (e.g. github, bitbucket, gitlab). It could be supplied directly in your config file.
+The `team_id` is also a required field, and could also be accessed using an environment variable as shown in the example above. Since the `team_id` is not a secret, however, this is not strictly necessary. It could be supplied directly in your config file. 
 
 More information on CTO.ai Workflow Metrics: https://cto.ai/docs/workflow-metrics
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Use the Orb to send events to CTO.ai by calling it from your `steps`:
             image: branch-label-543
             name: user
             origin: shell
+            vcs_type: github
 ```
 
 Note: only `token` and `team_id` are required fields. The other fields are optional.
@@ -29,7 +30,9 @@ Note: only `token` and `team_id` are required fields. The other fields are optio
 
 You can set your environmenta variables in a CircleCI Context, in your Organization Settings, or on your Project Settings. The environment variable must then be accessed from the user's CircleCI config (e.g. `CTOAI_EVENTS_API_TOKEN` as seen above) and passed to the Orb to use the CTO.ai Events API.
 
-The `team_id` is also a required field, and could also be accessed using an environment variable as shown in the example above. Since the `team_id` is not a secret, however, this is not strictly necessary. It could be supplied directly in your config file. 
+The `team_id` is also a required field, and could also be accessed using an environment variable as shown in the example above. Since the `team_id` is not a secret, however, this is not strictly necessary. It could be supplied directly in your config file.
+
+The `vcs_type` parameter specifies the vcs used (e.g. github, bitbucket, gitlab). It could be supplied directly in your config file.
 
 More information on CTO.ai Workflow Metrics: https://cto.ai/docs/workflow-metrics
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ If your CICD runs on CircleCI, you can use the CTO.ai CircleCI Orb to make it ea
 
 ```
 orbs:
-  cto-ai: cto-ai/cto-ai@1.0.1
+  cto-ai: cto-ai/cto-ai@1.0.3
 ```
 
 Use the Orb to send events to CTO.ai by calling it from your `steps`:


### PR DESCRIPTION
PR to update the example using the new orb version (cto-ai/cto-ai@1.0.3) and removing the origin parameter